### PR TITLE
[review] specify protocol to asset_host

### DIFF
--- a/lib/static_resources_rails.rb
+++ b/lib/static_resources_rails.rb
@@ -11,7 +11,7 @@ module StaticResourcesRails
 
     def bucket=(value)
       @bucket = value
-      Rails.application.config.action_controller.asset_host = "#{@bucket}.s3.#{region}.amazonaws.com"
+      Rails.application.config.action_controller.asset_host = "https://#{@bucket}.s3.#{region}.amazonaws.com"
       Rails.application.config.assets.manifest = "public/assets/#{sprockets_manifest_filename}"
     end
 

--- a/lib/static_resources_rails/tasks.rb
+++ b/lib/static_resources_rails/tasks.rb
@@ -17,7 +17,7 @@ namespace :static_resources do
     manifest_files = ["assets/#{StaticResourcesRails.sprockets_manifest_filename}", 'packs/manifest.json']
 
     manifest_files.each do |manifest_file|
-      download_url = "https://#{Rails.application.config.action_controller.asset_host}/#{manifest_file}"
+      download_url = "#{Rails.application.config.action_controller.asset_host}/#{manifest_file}"
       file_path = Rails.public_path.join(manifest_file)
       file_path.parent.mkdir unless file_path.parent.exist?
       IO.write(file_path, URI.open(download_url).read)


### PR DESCRIPTION
protocolの指定がないため、API等でpacksのimageを返す際にプロトコル情報が指定されておらず、ネイティブアプリ側でプロトコルの指定が求められてしまう。
manifestファイルをダウンロードする際にもhttpsを補完しており、面倒事が増えるためhttps指定としたい。