### PR TITLE
additional_* をデフォルトで空にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ StaticResourcesRails.additional_sync_dirs = %w[vite]
 StaticResourcesRails.additional_manifest_files = %w[vite/manifest.json vite/manifest-assets.json]
 ```
 
+### With webpacker
+
+`config/initializers/static_resources_rails.rb`
+```ruby
+StaticResourcesRails.additional_sync_dirs = %w[packs]
+StaticResourcesRails.additional_manifest_files = %w[packs/manifest.json]
+```
+
 ## Tasks
 
 ### `static_resources:sync_s3`

--- a/README.md
+++ b/README.md
@@ -119,3 +119,19 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.STATIC_RESOURCES_AWS_SECRET_KEY_ID }}
         run: bundle exec rake static_resources:sync_s3
 ```
+
+## With OpsWorks
+
+Skip `assets:precompile` on deploying. Add below lines to Layer's Custom JSON:
+
+```
+{
+    "deploy": {
+        "YOUR_APP_NAME": {
+            "framework": {
+                "assets_precompile": false
+            }
+        }
+    }
+}
+```

--- a/lib/static_resources_rails.rb
+++ b/lib/static_resources_rails.rb
@@ -26,6 +26,6 @@ module StaticResourcesRails
 
   self.region = 'ap-northeast-1'
   self.sprockets_manifest_filename = '.sprockets-manifest.json'
-  self.additional_sync_dirs = %w[packs]
-  self.additional_manifest_files = %w[packs/manifest.json]
+  self.additional_sync_dirs = []
+  self.additional_manifest_files = []
 end

--- a/lib/static_resources_rails/storage.rb
+++ b/lib/static_resources_rails/storage.rb
@@ -15,10 +15,7 @@ module StaticResourcesRails
     end
 
     def sync
-      dir = Rails.public_path.join(@dir)
-      return unless dir.directory?
-
-      dir.find do |path|
+      Rails.public_path.join(@dir).find do |path|
         next if path.directory?
 
         upload_file(path)

--- a/lib/static_resources_rails/storage.rb
+++ b/lib/static_resources_rails/storage.rb
@@ -15,7 +15,10 @@ module StaticResourcesRails
     end
 
     def sync
-      Rails.public_path.join(@dir).find do |path|
+      dir = Rails.public_path.join(@dir)
+      return unless dir.directory?
+
+      dir.find do |path|
         next if path.directory?
 
         upload_file(path)


### PR DESCRIPTION
webpacker を使っていないプロジェクトで `additional_sync_dirs = []` をしないとエラーになってしまうことへの対処です。