### PR TITLE
manifestダウンロードでasset_hostを参照しないように

### DIFF
--- a/lib/static_resources_rails.rb
+++ b/lib/static_resources_rails.rb
@@ -17,9 +17,8 @@ module StaticResourcesRails
     def set_bucket(value, with_asset_host: true)
       @bucket = value
       if with_asset_host
-        asset_host = "#{@bucket}.s3.#{region}.amazonaws.com"
-        Rails.application.config.action_controller.asset_host = asset_host
-        Rails.application.config.action_mailer.asset_host = asset_host
+        Rails.application.config.action_controller.asset_host = bucket_host
+        Rails.application.config.action_mailer.asset_host = bucket_host
       end
       Rails.application.config.assets.manifest = "public/assets/#{sprockets_manifest_filename}"
     end
@@ -28,6 +27,10 @@ module StaticResourcesRails
       raise Error, 'bucket is empty!' unless @bucket
 
       @bucket
+    end
+
+    def bucket_host
+      "#{bucket}.s3.#{region}.amazonaws.com"
     end
   end
 

--- a/lib/static_resources_rails/tasks.rb
+++ b/lib/static_resources_rails/tasks.rb
@@ -17,7 +17,7 @@ namespace :static_resources do
     manifest_files = ["assets/#{StaticResourcesRails.sprockets_manifest_filename}", *StaticResourcesRails.additional_manifest_files]
 
     manifest_files.each do |manifest_file|
-      download_url = "https://#{Rails.application.config.action_controller.asset_host}/#{manifest_file}"
+      download_url = "https://#{StaticResourcesRails.bucket_host}/#{manifest_file}"
       file_path = Rails.public_path.join(manifest_file)
       file_path.parent.mkdir unless file_path.parent.exist?
       IO.write(file_path, URI.open(download_url).read)


### PR DESCRIPTION
- S3バケットをasset_hostとして使わない場合にmanifestダウンロードに失敗する場合があるのを修正